### PR TITLE
Fixed DELETE endpoint to return 204 NO_CONTENT and updated tests

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -210,16 +210,14 @@ def delete_inventories(inventory_id):
 
     # Find the inventory
     inventory = Inventory.find(inventory_id)
-    if not inventory:
-        abort(
-            status.HTTP_404_NOT_FOUND,
-            f"Inventory with id '{inventory_id}' was not found.",
+    # If inventory exists, delete it
+    if inventory:
+        inventory.delete()
+        app.logger.info(
+            "Inventory with id [%s] as been successfully deleted.", inventory_id
         )
-
-    # Delete the inventory
-    inventory.delete()
-    app.logger.info("Inventory with ID [%s] delete complete.", inventory_id)
-
+    else:
+        app.logger.info("Inventory with id [%s] not found", inventory_id)
     return "", status.HTTP_204_NO_CONTENT
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -232,9 +232,9 @@ class TestYourResourceService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_non_existing_inventory(self):
-        """It should return 404 when trying to delete a non-existing Inventory"""
+        """It should return 204 when trying to delete a non-existing Inventory"""
         response = self.client.delete(f"{BASE_URL}/0")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     ############################################################
     # Utility function to bulk create inventories


### PR DESCRIPTION
Bug fix
1. When running flask, deleting an existing item returns HTTP_204_NO_CONTENT.
2. When running flask, deleting a nonexistent item also returns HTTP_204_NO_CONTENT.
3. Pytest passed