### PR TITLE
add error handler for invalid URL input

### DIFF
--- a/service/common/error_handlers.py
+++ b/service/common/error_handlers.py
@@ -35,3 +35,15 @@ def request_validation_error(error):
         "error": "Bad Request",
         "message": message,
     }, status.HTTP_400_BAD_REQUEST
+
+
+@app.errorhandler(status.HTTP_404_NOT_FOUND)
+def not_found(error):
+    """Handles resources not found with 404_NOT_FOUND"""
+    message = str(error)
+    app.logger.warning(message)
+    return {
+        "status": status.HTTP_404_NOT_FOUND,
+        "error": "URL Not Found",
+        "message": message,
+    }, status.HTTP_404_NOT_FOUND

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -419,6 +419,18 @@ class TestSadPaths(TestCase):
         response = self.client.get("api/error_test")
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    def test_not_found_error_handler(self):
+        """It should test the not_found error handler"""
+        # Make request to non-existent endpoint
+        response = self.client.get("/non_existent_endpoint")
+
+        # Assert the response
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertEqual(data["status_code"], status.HTTP_404_NOT_FOUND)
+        self.assertEqual(data["error"], "URL Not Found")
+        self.assertIn("message", data)
+
     ######################################################################
     #  T E S T   M O C K S
     ######################################################################


### PR DESCRIPTION
Description 
1. This is a function to handle invalid URL input which is useful for test in backend. 
2. 
<img width="776" alt="Screenshot 2024-11-26 at 11 06 22" src="https://github.com/user-attachments/assets/7bdac733-5d2a-47e2-8d6f-7bb71815e134">
<img width="919" alt="Screenshot 2024-11-26 at 11 07 02" src="https://github.com/user-attachments/assets/436423b5-cb70-4577-a6ba-6aee98a2ef8a">
When user type an invalid URL address, it will return warning massage both in terminal and webpage instead of corruption.
