### PR TITLE
404 Warning message with invalid URL input

### DIFF
--- a/service/common/error_handlers.py
+++ b/service/common/error_handlers.py
@@ -19,7 +19,8 @@ Module: error_handlers
 from flask import current_app as app  # Import Flask application
 from service.routes import api
 from service.models import DataValidationError
-from . import status
+from service.common import status
+from werkzeug.exceptions import NotFound
 
 
 ######################################################################
@@ -35,3 +36,15 @@ def request_validation_error(error):
         "error": "Bad Request",
         "message": message,
     }, status.HTTP_400_BAD_REQUEST
+
+
+@app.errorhandler(NotFound)
+def not_found(error):
+    """Handles resources not found with 404_NOT_FOUND"""
+    message = str(error)
+    app.logger.warning(message)
+    return {
+        "status_code": status.HTTP_404_NOT_FOUND,
+        "error": "URL Not Found",
+        "message": message,
+    }, status.HTTP_404_NOT_FOUND

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -419,6 +419,18 @@ class TestSadPaths(TestCase):
         response = self.client.get("api/error_test")
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    def test_not_found_error_handler(self):
+        """It should test the not_found error handler"""
+        # Make request to non-existent endpoint
+        response = self.client.get("/non_existent_endpoint")
+
+        # Assert the response
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertEqual(data["status_code"], status.HTTP_404_NOT_FOUND)
+        self.assertEqual(data["error"], "URL Not Found")
+        self.assertIn("message", data)
+
     ######################################################################
     #  T E S T   M O C K S
     ######################################################################


### PR DESCRIPTION
Description
1. This is a function to handle invalid URL input which is useful for test in backend.
2. When user type an invalid URL address, it will return warning massage both in terminal and webpage instead of corruption.
<img width="919" alt="Screenshot 2024-11-26 at 11 07 02" src="https://github.com/user-attachments/assets/d157063f-d6fd-4c18-aeb1-e14936f51d19">
<img width="776" alt="Screenshot 2024-11-26 at 11 06 22" src="https://github.com/user-attachments/assets/446e34bd-dee5-4753-9475-260f4507d0c7">
